### PR TITLE
Adding semantic versioning and bumpconfig support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:archstor/blueprint/__init__.py]
+
+[bumpversion:file:setup.py]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Archstor
 [![Build Status](https://travis-ci.org/bnbalsamo/archstor.svg?branch=master)](https://travis-ci.org/bnbalsamo/archstor) [![Coverage Status](https://coveralls.io/repos/github/bnbalsamo/archstor/badge.svg?branch=master)](https://coveralls.io/github/bnbalsamo/archstor?branch=master)
+
 (Note: Coverage status out of coveralls looks crummy, as it's not testing any of the swift backend code (though it has tests which pass in local environments) or the rough draft s3 code which is inaccessible at the moment.)
+
+v0.0.1
 
 ## About
 

--- a/archstor/blueprint/__init__.py
+++ b/archstor/blueprint/__init__.py
@@ -3,6 +3,8 @@ import logging
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 
+__version__ = "0.0.1"
+
 try:
     import boto3
     import botocore
@@ -437,6 +439,11 @@ class Object(Resource):
         return {"identifier": id, "deleted": True}
 
 
+class Version(Resource):
+    def get(self):
+        return {"version": __version__}
+
+
 @BLUEPRINT.record
 def handle_configs(setup_state):
     def configure_mongo(bp):
@@ -494,3 +501,4 @@ def handle_configs(setup_state):
 
 API.add_resource(Root, "/")
 API.add_resource(Object, "/<string:id>")
+API.add_resource(Version, "/version")

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ def readme():
 
 setup(
     name = "archstor",
+    version = "0.0.1",
     description = "abstract layer for archival object storage",
     long_description = readme(),
     packages = find_packages(

--- a/tests.py
+++ b/tests.py
@@ -109,6 +109,11 @@ class ArchstorTestCase:
         rv2 = self.app.put("/{}".format(id), data={"object": (obj2, "test.txt")})
         self.assertEqual(rv2.status_code, 400)
 
+    def test_Version(self):
+        rv = self.app.get("/version")
+        rj = self.response_200_json(rv)
+        self.assertEqual(rj['version'], archstor.blueprint.__version__)
+
 
 class MongoStorageTestCases(ArchstorTestCase, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Adds semantic versioning to the repository, as well as a /version endpoint to the API which returns the running version.